### PR TITLE
add scipy installation

### DIFF
--- a/01_how_to_use_qulacs.ipynb
+++ b/01_how_to_use_qulacs.ipynb
@@ -9,6 +9,7 @@
     "#!pip install qulacs\n",
     "#!pip install matplotlib\n",
     "#!pip install numpy\n",
+    "#!pip install scipy\n",
     "from utility import *"
    ]
   },

--- a/02_Ramsay.ipynb
+++ b/02_Ramsay.ipynb
@@ -9,6 +9,7 @@
     "#!pip install qulacs\n",
     "#!pip install matplotlib\n",
     "#!pip install numpy\n",
+    "#!pip install scipy\n",
     "from utility import *"
    ]
   },


### PR DESCRIPTION
01_how_to_use_qulacs.ipynb
02_Ramsay.ipynb
でも `from utility import *` にも scipyが必要なようなので，
インストールコマンドを追加しておいてもらえると初学者は助かります．
