### PR TITLE
[Fix] update urls in README.md to latest url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,58 +1,65 @@
 # 量子ソフトウェア勉強会ハンズオン
+
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD)
+
 - 量子計算の基礎
-  - 01_qulacsの使い方 
-<br> [01_how_to_use_qulacs.ipynb](./01_how_to_use_qulacs.ipynb) 
-<br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=01_how_to_use_qulacs.ipynb) 
-  - 02_ラムゼイ干渉を観測する 
-<br> [02_Ramsay.ipynb](./02_Ramsay.ipynb) 
-<br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=02_Ramsay.ipynb) 
-  - 03_量子演算を変分的に分解する
-<br> [03_VariationalGateDecomposition.ipynb](./03_VariationalGateDecomposition.ipynb)
-<br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=03_VariationalGateDecomposition.ipynb) 
-  - 04_量子ボリュームを計算する
-<br>[04_QuantumVolume.ipynb](./04_QuantumVolume.ipynb)
-<br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=04_QuantumVolume.ipynb) 
+
+  - 01_qulacs の使い方
+    <br> [01_how_to_use_qulacs.ipynb](./doc/source/notebooks/01_how_to_use_qulacs.ipynb)
+    <br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=doc/source/notebooks/01_how_to_use_qulacs.ipynb)
+  - 02\_ラムゼイ干渉を観測する
+    <br> [02_Ramsay.ipynb](./doc/source/notebooks/02_Ramsay.ipynb)
+    <br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=doc/source/notebooks/02_Ramsay.ipynb)
+  - 03\_量子演算を変分的に分解する
+    <br> [03_VariationalGateDecomposition.ipynb](./doc/source/notebooks/03_VariationalGateDecomposition.ipynb)
+    <br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=doc/source/notebooks/03_VariationalGateDecomposition.ipynb)
+  - 04\_量子ボリュームを計算する
+    <br>[04_QuantumVolume.ipynb](./doc/source/notebooks/04_QuantumVolume.ipynb)
+    <br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=doc/source/notebooks/04_QuantumVolume.ipynb)
 
 - (NISQ) 量子アルゴリズムの基礎
-  - 05_オブザーバブルのサンプリングによる推定
-<br>[05_sample_observable.ipynb](./05_sample_observable.ipynb)
-<br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=05_sample_observable.ipynb) 
-  - 06_パラメータシフト法による勾配最適化
-<br>[06_parameter_shift_rule.ipynb](./06_parameter_shift_rule.ipynb)
-<br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=06_parameter_shift_rule.ipynb) 
-  - 07_エラー補償法を学ぶ
-<br>[07_error_mitigation.ipynb](./07_error_mitigation.ipynb)
-<br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=07_error_mitigation.ipynb) 
+
+  - 05\_オブザーバブルのサンプリングによる推定
+    <br>[05_sample_observable.ipynb](./doc/source/notebooks/05_sample_observable.ipynb)
+    <br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=doc/source/notebooks/05_sample_observable.ipynb)
+  - 06\_パラメータシフト法による勾配最適化
+    <br>[06_parameter_shift_rule.ipynb](./doc/source/notebooks/06_parameter_shift_rule.ipynb)
+    <br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=doc/source/notebooks/06_parameter_shift_rule.ipynb)
+  - 07\_エラー補償法を学ぶ
+    <br>[07_error_mitigation.ipynb](./doc/source/notebooks/07_error_mitigation.ipynb)
+    <br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=doc/source/notebooks/07_error_mitigation.ipynb)
 
 - 量子機械学習
-  - 08_簡単な量子回路学習を実行してみる
-<br>[08_QCL.ipynb](./08_QCL.ipynb)
-<br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=08_QCL.ipynb) 
-  - 09_量子カーネル法を試してみる
-<br>[09_quantum_kernel.ipynb](./09_quantum_kernel.ipynb)
-<br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=09_quantum_kernel.ipynb) 
+
+  - 08\_簡単な量子回路学習を実行してみる
+    <br>[08_QCL.ipynb](./doc/source/notebooks/08_QCL.ipynb)
+    <br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=doc/source/notebooks/08_QCL.ipynb)
+  - 09\_量子カーネル法を試してみる
+    <br>[09_quantum_kernel.ipynb](./doc/source/notebooks/09_quantum_kernel.ipynb)
+    <br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=doc/source/notebooks/09_quantum_kernel.ipynb)
 
 - 量子化学
-   - 10_古典コンピュータを使った量子化学計算を実行してみる
-<br> [10_conventional_quantum_chemical_calculations.ipynb](./10_conventional_quantum_chemical_calculations.ipynb)
-<br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=10_conventional_quantum_chemical_calculations.ipynb)
-   - 11_量子コンピュータに量子化学の問題をマッピングしてみる
-<br> [11_fermion_qubit_mapping.ipynb](./11_fermion_qubit_mapping.ipynb)
-<br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=11_fermion_qubit_mapping.ipynb)
-   - 12_変分量子固有値法（VQE)を実行して分子の基底状態を計算してみる
-<br> [12_compute_groud_state_of_molecule_using_vqe.ipynb](./12_compute_groud_state_of_molecule_using_vqe.ipynb)
-<br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=12_compute_groud_state_of_molecule_using_vqe.ipynb)
+
+  - 10\_古典コンピュータを使った量子化学計算を実行してみる
+    <br> [10_conventional_quantum_chemical_calculations.ipynb](./doc/source/notebooks/10_conventional_quantum_chemical_calculations.ipynb)
+    <br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=doc/source/notebooks/10_conventional_quantum_chemical_calculations.ipynb)
+  - 11\_量子コンピュータに量子化学の問題をマッピングしてみる
+    <br> [11_fermion_qubit_mapping.ipynb](./doc/source/notebooks/11_fermion_qubit_mapping.ipynb)
+    <br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=doc/source/notebooks/11_fermion_qubit_mapping.ipynb)
+  - 12\_変分量子固有値法（VQE)を実行して分子の基底状態を計算してみる
+    <br> [12_compute_groud_state_of_molecule_using_vqe.ipynb](./doc/source/notebooks/12_compute_groud_state_of_molecule_using_vqe.ipynb)
+    <br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=doc/source/notebooks/12_compute_groud_state_of_molecule_using_vqe.ipynb)
 
 - 量子アルゴリズム
-   - 13_量子位相推定
-<br> [13_quantum_phase_estimation.ipynb](./13_quantum_phase_estimation.ipynb)
-<br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=13_quantum_phase_estimation.ipynb)
-   - 14_グローバー量子探索アルゴリズム
-<br> [14_grover_search.ipynb](./14_grover_search.ipynb)
-<br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=14_grover_search.ipynb)
+
+  - 13\_量子位相推定
+    <br> [13_quantum_phase_estimation.ipynb](./doc/source/notebooks/13_quantum_phase_estimation.ipynb)
+    <br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=doc/source/notebooks/13_quantum_phase_estimation.ipynb)
+  - 14\_グローバー量子探索アルゴリズム
+    <br> [14_grover_search.ipynb](./doc/source/notebooks/14_grover_search.ipynb)
+    <br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?filepath=doc/source/notebooks/14_grover_search.ipynb)
 
 - 金融への応用
-   - 15_QAEを用いた信用ポートフォリオリスク計測
-<br> [15_CreditPortfolioRisk/CreditPortfolioRiskMeasurement_blank.ipynb](./15_CreditPortfolioRisk/CreditPortfolioRiskMeasurement_blank.ipynb)
-<br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson.git/HEAD?labpath=15_CreditPortfolioRisk%2FCreditPortfolioRiskMeasurement_blank.ipynb)
+  - 15_QAE を用いた信用ポートフォリオリスク計測
+    <br> [15_CreditPortfolioRisk/CreditPortfolioRiskMeasurement_blank.ipynb](./doc/source/notebooks/15_CreditPortfolioRisk/CreditPortfolioRiskMeasurement_blank.ipynb)
+    <br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson.git/HEAD?filepath=15_CreditPortfolioRisk%2FCreditPortfolioRiskMeasurement_blank.ipynb)

--- a/README.md
+++ b/README.md
@@ -62,4 +62,4 @@
 - 金融への応用
   - 15_QAE を用いた信用ポートフォリオリスク計測
     <br> [15_CreditPortfolioRisk/CreditPortfolioRiskMeasurement_blank.ipynb](./doc/source/notebooks/15_CreditPortfolioRisk/CreditPortfolioRiskMeasurement_blank.ipynb)
-    <br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson.git/HEAD?filepath=15_CreditPortfolioRisk%2FCreditPortfolioRiskMeasurement_blank.ipynb)
+    <br> [[mybindで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson.git/HEAD?filepath=doc/source/notebooks/15_CreditPortfolioRisk/CreditPortfolioRiskMeasurement_blank.ipynb)


### PR DESCRIPTION
closing #24 
# 概要
ディレクトリ構造の変更などによってURLが指す先が変化していたため、README.mdに書かれているURLと内容が一致していませんでした。
このプルリクではREADME.mdに書かれているURLを最新のものに更新します。