### PR TITLE
[Feat] :hammer: add sphinx-sitemap extension for auto-gen sitemap.xml

### DIFF
--- a/doc/requirements-doc.txt
+++ b/doc/requirements-doc.txt
@@ -2,6 +2,6 @@ alabaster
 sphinx
 sphinx-notfound-page
 sphinx-book-theme
+sphinx-sitemap
 ipykernel
 nbsphinx
-

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -34,6 +34,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
     "nbsphinx",
+    "sphinx_sitemap",
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
close #35 

検索エンジンがサイトを認識するために必要な、sitemap.xmlを自動生成するようにsphinxの拡張機能を導入しました。
このプルリクによって検索エンジンのインデックスに引っかかる確率を増やすことができます。