### PR TITLE
Absolute link on toppage

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,9 @@
 
 - 07\_量子コンピュータと金融実務計算
 
-  - 01_QAE を用いた信用ポートフォリオリスク計測
-    <br> [07_CreditPortfolioRisk/07_01_CreditPortfolioRiskMeasurement_blank.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/07_CreditPortfolioRisk/07_01_CreditPortfolioRiskMeasurement_blank.ipynb)
-    <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson.git/HEAD?labpath=doc/source/notebooks/07_CreditPortfolioRisk/07_01_CreditPortfolioRiskMeasurement_blank.ipynb)
+  - 01_QAE を用いたデジタルオプションプライシング
+    <br> [07_DerivativePricing/07_01_DerivativePricing.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/07_DerivativePricing/07_01_DerivativePricing.ipynb)
+    <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson.git/HEAD?labpath=doc/source/notebooks/07_DerivativePricing/07_01_DerivativePricing.ipynb)
 
 - 08\_量子インスパイアード古典アルゴリズム
 

--- a/README.md
+++ b/README.md
@@ -8,92 +8,92 @@
 - 01\_量子計算の基礎
 
   - 00_量子計算の基礎 1000本ノック
-    <br> [01_00_quantum_computation_1000practices.ipynb](./doc/source/notebooks/01_00_quantum_computation_1000practices.ipynb)
+    <br> [01_00_quantum_computation_1000practices.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/01_00_quantum_computation_1000practices.ipynb)
     <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?labpath=doc/source/notebooks/01_00_quantum_computation_1000practices.ipynb)
   - 01_qulacs の使い方
-    <br> [01_01_how_to_use_qulacs.ipynb](./doc/source/notebooks/01_01_how_to_use_qulacs.ipynb)
+    <br> [01_01_how_to_use_qulacs.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/01_01_how_to_use_qulacs.ipynb)
     <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?labpath=doc/source/notebooks/01_01_how_to_use_qulacs.ipynb)
   - 02\_ラムゼイ干渉を観測する
-    <br> [01_02_Ramsay.ipynb](./doc/source/notebooks/01_02_Ramsay.ipynb)
+    <br> [01_02_Ramsay.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/01_02_Ramsay.ipynb)
     <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?labpath=doc/source/notebooks/01_02_Ramsay.ipynb)
   - 03\_量子演算を変分的に分解する
-    <br> [01_03_VariationalGateDecomposition.ipynb](./doc/source/notebooks/01_03_VariationalGateDecomposition.ipynb)
+    <br> [01_03_VariationalGateDecomposition.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/01_03_VariationalGateDecomposition.ipynb)
     <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?labpath=doc/source/notebooks/01_03_VariationalGateDecomposition.ipynb)
   - 04\_量子ボリュームを計算する
-    <br> [01_04_QuantumVolume.ipynb](./doc/source/notebooks/01_04_QuantumVolume.ipynb)
+    <br> [01_04_QuantumVolume.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/01_04_QuantumVolume.ipynb)
     <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?labpath=doc/source/notebooks/01_04_QuantumVolume.ipynb)
 
 - 02\_(NISQ)量子アルゴリズムの基礎
 
   - 01\_オブザーバブルのサンプリングによる推定
-    <br> [02_01_sample_observable.ipynb](./doc/source/notebooks/02_01_sample_observable.ipynb)
+    <br> [02_01_sample_observable.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/02_01_sample_observable.ipynb)
     <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?labpath=doc/source/notebooks/02_01_sample_observable.ipynb)
   - 02\_パラメータシフト法による勾配最適化
-    <br> [02_02_parameter_shift_rule.ipynb](./doc/source/notebooks/02_02_parameter_shift_rule.ipynb)
+    <br> [02_02_parameter_shift_rule.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/02_02_parameter_shift_rule.ipynb)
     <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?labpath=doc/source/notebooks/02_02_parameter_shift_rule.ipynb)
 
 - 03\_量子機械学習の基礎
 
   - 01\_簡単な量子回路学習を実行してみる
-    <br> [03_01_QCL.ipynb](./doc/source/notebooks/03_01_QCL.ipynb)
+    <br> [03_01_QCL.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/03_01_QCL.ipynb)
     <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?labpath=doc/source/notebooks/03_01_QCL.ipynb)
   - 02\_量子カーネル法を試してみる
-    <br> [03_02_quantum_kernel.ipynb](./doc/source/notebooks/03_02_quantum_kernel.ipynb)
+    <br> [03_02_quantum_kernel.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/03_02_quantum_kernel.ipynb)
     <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?labpath=doc/source/notebooks/03_02_quantum_kernel.ipynb)
 
 - 04\_量子エラー補償の基礎
 
   - 01\_Qulacsでの混合状態
-    <br> [04_01_Density_Matrix_and_Error.ipynb](./doc/source/notebooks/04_01_Density_Matrix_and_Error.ipynb)
+    <br> [04_01_Density_Matrix_and_Error.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/04_01_Density_Matrix_and_Error.ipynb)
     <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?labpath=doc/source/notebooks/04_01_Density_Matrix_and_Error.ipynb)
   - 02\_リチャードソン外挿法と指数関数外挿法を実装してみる
-    <br> [04_02_Extrapolation.ipynb](./doc/source/notebooks/04_02_Extrapolation.ipynb)
+    <br> [04_02_Extrapolation.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/04_02_Extrapolation.ipynb)
     <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?labpath=doc/source/notebooks/04_02_Extrapolation.ipynb)
   - 03\_擬確率法を実装してみる
-    <br> [04_03_Probabilistic_error_cancellation.ipynb](./doc/source/notebooks/04_03_Probabilistic_error_cancellation.ipynb)
+    <br> [04_03_Probabilistic_error_cancellation.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/04_03_Probabilistic_error_cancellation.ipynb)
     <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?labpath=doc/source/notebooks/04_03_Probabilistic_error_cancellation.ipynb)
 
 - 05\_量子コンピュータと量子化学の基礎
 
   - 01\_古典コンピュータを使った量子化学計算を実行してみる
-    <br> [05_01_conventional_quantum_chemical_calculations.ipynb](./doc/source/notebooks/05_01_conventional_quantum_chemical_calculations.ipynb)
+    <br> [05_01_conventional_quantum_chemical_calculations.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/05_01_conventional_quantum_chemical_calculations.ipynb)
     <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?labpath=doc/source/notebooks/05_01_conventional_quantum_chemical_calculations.ipynb)
   - 02\_量子コンピュータに量子化学の問題をマッピングしてみる
-    <br> [05_02_fermion_qubit_mapping.ipynb](./doc/source/notebooks/05_02_fermion_qubit_mapping.ipynb)
+    <br> [05_02_fermion_qubit_mapping.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/05_02_fermion_qubit_mapping.ipynb)
     <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?labpath=doc/source/notebooks/05_02_fermion_qubit_mapping.ipynb)
   - 03\_変分量子固有値法（VQE)を実行して分子の基底状態を計算してみる
-    <br> [05_03_compute_groud_state_of_molecule_using_vqe.ipynb](./doc/source/notebooks/05_03_compute_groud_state_of_molecule_using_vqe.ipynb)
+    <br> [05_03_compute_groud_state_of_molecule_using_vqe.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/05_03_compute_groud_state_of_molecule_using_vqe.ipynb)
     <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?labpath=doc/source/notebooks/05_03_compute_groud_state_of_molecule_using_vqe.ipynb)
   - 04\_Qamuyを使った量子コンピュータｘ量子化学計算
-    <br> [05_04_compute_chemical_properties_using_Qamuy.ipynb](./doc/source/notebooks/05_04_compute_chemical_properties_using_Qamuy.ipynb)
+    <br> [05_04_compute_chemical_properties_using_Qamuy.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/05_04_compute_chemical_properties_using_Qamuy.ipynb)
     <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?labpath=doc/source/notebooks/05_04_compute_chemical_properties_using_Qamuy.ipynb)
 
 - 06\_量子アルゴリズム各論
 
   - 01\_量子位相推定
-    <br> [06_01_quantum_phase_estimation.ipynb](./doc/source/notebooks/06_01_quantum_phase_estimation.ipynb)
+    <br> [06_01_quantum_phase_estimation.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/06_01_quantum_phase_estimation.ipynb)
     <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?labpath=doc/source/notebooks/06_01_quantum_phase_estimation.ipynb)
   - 02\_グローバー量子探索アルゴリズム
-    <br> [06_02_grover_search.ipynb](./doc/source/notebooks/06_02_grover_search.ipynb)
+    <br> [06_02_grover_search.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/06_02_grover_search.ipynb)
     <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson/HEAD?labpath=doc/source/notebooks/06_02_grover_search.ipynb)
 
 - 07\_量子コンピュータと金融実務計算
 
   - 01_QAE を用いた信用ポートフォリオリスク計測
-    <br> [07_CreditPortfolioRisk/07_01_CreditPortfolioRiskMeasurement_blank.ipynb](./doc/source/notebooks/07_CreditPortfolioRisk/07_01_CreditPortfolioRiskMeasurement_blank.ipynb)
+    <br> [07_CreditPortfolioRisk/07_01_CreditPortfolioRiskMeasurement_blank.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/07_CreditPortfolioRisk/07_01_CreditPortfolioRiskMeasurement_blank.ipynb)
     <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson.git/HEAD?labpath=doc/source/notebooks/07_CreditPortfolioRisk/07_01_CreditPortfolioRiskMeasurement_blank.ipynb)
 
 - 08\_量子インスパイアード古典アルゴリズム
 
   - 01_ $\mathrm{SQ}(A)$と $\mathrm{SQ}(b)$の実装について
-    <br> [08_01_Data_structure.ipynb](./doc/source/notebooks/08_01_Data_structure.ipynb)
+    <br> [08_01_Data_structure.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/08_01_Data_structure.ipynb)
     <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson.git/HEAD?labpath=doc/source/notebooks/08_01_Data_structure.ipynb)
   - 02_ $x = A^+b$に関する量子インスパイアード古典アルゴリズム Part 1
-    <br> [08_02_Quantum_inspired_classical_algorithm_Part1.ipynb](./doc/source/notebooks/08_02_Quantum_inspired_classical_algorithm_Part1.ipynb)
+    <br> [08_02_Quantum_inspired_classical_algorithm_Part1.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/08_02_Quantum_inspired_classical_algorithm_Part1.ipynb)
     <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson.git/HEAD?labpath=doc/source/notebooks/08_02_Quantum_inspired_classical_algorithm_Part1.ipynb)
   - 03_ $x = A^+ b$に関する量子インスパイアード古典アルゴリズム Part 2
-    <br> [08_03_Quantum_inspired_classical_algorithm_Part2.ipynb](./doc/source/notebooks/08_03_Quantum_inspired_classical_algorithm_Part2.ipynb)
+    <br> [08_03_Quantum_inspired_classical_algorithm_Part2.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/08_03_Quantum_inspired_classical_algorithm_Part2.ipynb)
     <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson.git/HEAD?labpath=doc/source/notebooks/08_03_Quantum_inspired_classical_algorithm_Part2.ipynb)
   - 04_2クラス問題に対する量子インスパイアード古典アルゴリズム
-    <br> [08_04_quantum_inspired_binary_classification.ipynb](./doc/source/notebooks/08_04_quantum_inspired_binary_classification.ipynb)
+    <br> [08_04_quantum_inspired_binary_classification.ipynb](https://github.com/Qulacs-Osaka/quantum_software_handson/blob/main/doc/source/notebooks/08_04_quantum_inspired_binary_classification.ipynb)
     <br> [[MyBinderで開く]](https://mybinder.org/v2/gh/Qulacs-Osaka/quantum_software_handson.git/HEAD?labpath=doc/source/notebooks/08_04_quantum_inspired_binary_classification.ipynb)


### PR DESCRIPTION
close #102
トップページのipynbへのリンクをgithub.com上のmainブランチのものへの絶対パスに書き換えました。
07_*のタイトルやファイル名が変更されていたのでそれも変更しました。