### PR TITLE
Fix Sdag matrix

### DIFF
--- a/doc/source/notebooks/01_01_how_to_use_qulacs.ipynb
+++ b/doc/source/notebooks/01_01_how_to_use_qulacs.ipynb
@@ -462,7 +462,7 @@
     "\\end{array}\n",
     "\\right)$,\n",
     "`Sdag` $=\n",
-    "\\frac{1}{\\sqrt{2}}\\left(\\begin{array}{cc}\n",
+    "\\left(\\begin{array}{cc}\n",
     "1 & 0\n",
     "\\\\\n",
     "0 & -i\n",


### PR DESCRIPTION
#110 の`01_00_quantum_computation_1000practices.ipynb`と同じで

`01_01_how_to_use_qulacs.ipynb`のSdagの行列表現が間違っていたので、修正しました。